### PR TITLE
FIX FIND ALL METHOD FOR BLOBJ NOW ORDER BY RANK

### DIFF
--- a/Aapi/src/main/java/com/example/Aapi/controller/BlobJController.java
+++ b/Aapi/src/main/java/com/example/Aapi/controller/BlobJController.java
@@ -28,6 +28,7 @@ import com.example.Aapi.exception.AapiEntityException;
 import com.example.Aapi.service.BlobJService;
 import com.example.Aapi.service.TagService;
 
+//TODO: Rank could be null. If so auto-generate rank
 //TODO: Implement unit test
 
 /**

--- a/Aapi/src/main/java/com/example/Aapi/dto/BlobJ.java
+++ b/Aapi/src/main/java/com/example/Aapi/dto/BlobJ.java
@@ -58,7 +58,7 @@ public class BlobJ {
     private Set<BlobJ> linkedBlobJ;
     
 	/*
-     * Override method toSTring
+     * Override method toString
      */
     @Override
     public String toString() {

--- a/Aapi/src/main/java/com/example/Aapi/service/BlobJService.java
+++ b/Aapi/src/main/java/com/example/Aapi/service/BlobJService.java
@@ -81,11 +81,11 @@ public class BlobJService {
 	/**
 	 * Retrieve all BlobJ per page - 50 blobJ/page.
 	 * @param pageNumber number of the page requested - 0 base count
-	 * @return required page with 50 blobJ sorted by name - Page<BlobJ>
+	 * @return required page with 50 blobJ sorted by rank - Page<BlobJ>
 	 */
 	public Page<BlobJ> retrieveAllBlobJs(Integer pageNumber) {
 		
-		Pageable pageable = PageRequest.of(pageNumber, NUM_OF_BLOBJ_PER_PAGE, Sort.by("name"));
+		Pageable pageable = PageRequest.of(pageNumber, NUM_OF_BLOBJ_PER_PAGE, Sort.by("rank"));
 		
 		Page<BlobJ> blobjs = blobJRepository.findAll(pageable);
 		


### PR DESCRIPTION
Fix retrieveAllBlobJs method in BlobJ service to order the returned
page by rank not by name.
Fix documentation.