### PR TITLE
FIX STRINGHELPERCLASS METHOD TURNED INTO STATIC METHODS

### DIFF
--- a/Aapi/src/main/java/com/example/Aapi/helper/StringFormatHelper.java
+++ b/Aapi/src/main/java/com/example/Aapi/helper/StringFormatHelper.java
@@ -1,6 +1,5 @@
 package com.example.Aapi.helper;
 
-import org.springframework.stereotype.Service;
 import org.apache.commons.text.WordUtils;
 
 /**
@@ -10,7 +9,6 @@ import org.apache.commons.text.WordUtils;
  * @author Aymeric NEUMANN
  *
  */
-@Service
 public class StringFormatHelper {
 
 	/**
@@ -18,7 +16,7 @@ public class StringFormatHelper {
 	 * @param toCapitalize String to capitalize
 	 * @return capitalized String - first word only
 	 */
-	public String capitalize(String toCapitalize) {
+	public static String capitalize(String toCapitalize) {
 		return WordUtils.capitalize(toCapitalize);
 	}
 	
@@ -27,7 +25,7 @@ public class StringFormatHelper {
 	 * @param toCapitalize String to capitalize
 	 * @return capitalized String - each word
 	 */
-	public String capitalizeFully(String toCapitalize) {
+	public static String capitalizeFully(String toCapitalize) {
 		return WordUtils.capitalizeFully(toCapitalize);
 	}
 }

--- a/Aapi/src/main/java/com/example/Aapi/service/BlobJService.java
+++ b/Aapi/src/main/java/com/example/Aapi/service/BlobJService.java
@@ -38,10 +38,6 @@ public class BlobJService {
 	@Autowired
 	BlobJRepository blobJRepository;
 	
-	/** Reference to the String Format Helper */
-	@Autowired
-	StringFormatHelper stringFormatHelper;
-
 	/**
 	 * Save the blobJ in the database.
 	 * @param blobj blobJ to save
@@ -378,7 +374,7 @@ public class BlobJService {
 		
 		//regex : [a-zA-Z\\-]*\\s*Blob$
 		
-		String formattedName = stringFormatHelper.capitalizeFully(blobJToFormat.getName());
+		String formattedName = StringFormatHelper.capitalizeFully(blobJToFormat.getName());
 		
         if (!formattedName.matches("[a-zA-Z\\-]*\\s*Blob$")) {
         	StringBuilder message = new StringBuilder();

--- a/Aapi/src/main/java/com/example/Aapi/service/TagService.java
+++ b/Aapi/src/main/java/com/example/Aapi/service/TagService.java
@@ -35,11 +35,7 @@ public class TagService {
 	/** Reference to the Tag Repository */
 	@Autowired
 	TagRepository tagRepository;
-	
-	/** Reference to the String Format Helper */
-	@Autowired
-	StringFormatHelper stringFormatHelper;
-	
+		
 	/**
 	 * Save the Tag in the database.
 	 * @param tag tag to save
@@ -199,7 +195,7 @@ public class TagService {
 	 */
 	private Tag formatTagData(Tag tagToFormat) {
 		
-		String formattedName = stringFormatHelper.capitalize(tagToFormat.getName());
+		String formattedName = StringFormatHelper.capitalize(tagToFormat.getName());
 		
 		tagToFormat.setName(formattedName);
 		


### PR DESCRIPTION
StringFormatHelper class in no more annotated with @Service
capitalize and capitalizeFully methods are now static.
Delete @Autowired annotation for StringFormatHelper in
BlobJService and TagService.
Fix checkAndFormatBlobJData method in BlobJService.
Fix formatTagData method in TagService.